### PR TITLE
Avoid error due to missing =

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -133,7 +133,7 @@ func compile(c *cli.Context, version, buildDir string) {
 
 	options := []string{
 		"-ldflags",
-		"-X main.GitCommit " + gitCommit,
+		"-X main.GitCommit=" + gitCommit,
 		"-output",
 		filepath.Join(buildDir, "{{.OS}}_{{.Arch}}", "{{.Dir}}"),
 	}


### PR DESCRIPTION
`-X flag requires argument of the form importpath.name=value`